### PR TITLE
[Mission5/박노철] Project_Notion_VanillaJs 과제

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -17,10 +17,11 @@
       <aside class="listPage">
         <div class="list"></div>
       </aside>
+
       <div class="editorPage">
         <div class="editor">
-          <input type="text" class="title" name="title" />
-          <textarea name="content" class="content"> </textarea>
+          <input name="title" id="title" />
+          <textarea name="content" id="content"></textarea>
         </div>
       </div>
     </main>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mission5</title>
+    <script type="module" src="/main.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mission5</title>
     <script type="module" src="/main.js"></script>
+    <link rel="stylesheet" href="/src/css/main.css" />
     <link rel="shortcut icon" href="#" />
   </head>
   <body>
@@ -16,7 +17,12 @@
       <aside class="listPage">
         <div class="list"></div>
       </aside>
-      <div class="editorPage"></div>
+      <div class="editorPage">
+        <div class="editor">
+          <input type="text" class="title" name="title" />
+          <textarea name="content" class="content"> </textarea>
+        </div>
+      </div>
     </main>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mission5</title>
     <script type="module" src="/main.js"></script>
+    <link rel="shortcut icon" href="#" />
   </head>
-  <body></body>
+  <body>
+    <header>
+      <h1>notion project</h1>
+      <span class="header--loading">loading....</span>
+    </header>
+    <main class="App">
+      <aside class="listPage">
+        <div class="list"></div>
+      </aside>
+      <div class="editorPage"></div>
+    </main>
+  </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const $sidebar = $app.querySelector(".listPage");
 const $editor = $app.querySelector(".editorPage");
 
 const listPage = new ListPage({ $target: $sidebar });
+//titl변경시만 onEdit이 호출되도록, 디바운스도 설정되어야한다.
 const editorPage = new EditorPage({
   $target: $editor,
   onEdit: () => {
@@ -14,4 +15,6 @@ const editorPage = new EditorPage({
   },
 });
 
-initRouter(() => editorPage.setState());
+initRouter(() => {
+  editorPage.setState();
+});

--- a/main.js
+++ b/main.js
@@ -1,0 +1,17 @@
+import EditorPage from "./src/pages/EditorPage.js";
+import ListPage from "./src/pages/ListPage.js";
+import { initRouter } from "./src/utils/router.js";
+
+const $app = document.querySelector(".App");
+const $sidebar = $app.querySelector(".listPage");
+const $editor = $app.querySelector(".editorPage");
+
+const listPage = new ListPage({ $target: $sidebar });
+const editorPage = new EditorPage({
+  $target: $editor,
+  onEdit: () => {
+    listPage.render();
+  },
+});
+
+initRouter(() => editorPage.setState());

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -5,12 +5,10 @@ export default class DocumentList {
     this.state = initialState;
     this.$target = $target;
     this.$page = $target.querySelector(".list");
-
     this.$page.addEventListener("click", (e) => {
       const { target } = e;
       onClickButton(target);
     });
-
     this.render();
   }
 
@@ -36,9 +34,10 @@ export default class DocumentList {
     <ul>
     ${state
       .map(
-        (doc) => `<li data-id=${doc.id}>${
+        (doc) => `<li data-id=${doc.id}>
+        <span class="list__title">${
           doc.title
-        } <button class="list__add-button--document">+</button><button class="list__add-button--delete">-</button>
+        }</span> <button class="list__add-button--document">+</button><button class="list__add-button--delete">-</button>
       ${doc.documents.length > 0 ? this.#convertIntoHTML(doc.documents) : ""}</li>`
       )
       .join(" ")}

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -24,12 +24,12 @@ export default class DocumentList {
   };
 
   render = () => {
-    const stateHTML = this.#convertIntoHTML(this.state);
+    const stateHTML = this._convertIntoHTML(this.state);
     this.$page.innerHTML = `<button class="list__add-button--root">add RootDocument</button>${stateHTML}`;
     this.$target.appendChild(this.$page);
   };
 
-  #convertIntoHTML = (state) => {
+  _convertIntoHTML = (state) => {
     return `
     <ul>
     ${state
@@ -38,7 +38,7 @@ export default class DocumentList {
         <span class="list__title">${
           doc.title
         }</span> <button class="list__add-button--document">+</button><button class="list__add-button--delete">-</button>
-      ${doc.documents.length > 0 ? this.#convertIntoHTML(doc.documents) : ""}</li>`
+      ${doc.documents.length > 0 ? this._convertIntoHTML(doc.documents) : ""}</li>`
       )
       .join(" ")}
     </ul>`;

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -1,26 +1,45 @@
+import { validateListState } from "../utils/validation.js";
+
 export default class DocumentList {
-  constructor({ $target, initialState }) {
+  constructor({ $target, initialState, onClickButton }) {
     this.state = initialState;
     this.$target = $target;
+    this.$page = $target.querySelector(".list");
+
+    this.$page.addEventListener("click", (e) => {
+      const { target } = e;
+      onClickButton(target);
+    });
 
     this.render();
   }
+
   setState = (nextState) => {
-    this.state = nextState;
+    try {
+      validateListState(nextState);
+      this.state = nextState;
+    } catch (error) {
+      console.log(error);
+      this.state = [];
+    }
     this.render();
   };
 
   render = () => {
     const stateHTML = this.#convertIntoHTML(this.state);
-    this.$target.innerHTML = stateHTML;
+    this.$page.innerHTML = `<button class="list__add-button--root">add RootDocument</button>${stateHTML}`;
+    this.$target.appendChild(this.$page);
   };
 
   #convertIntoHTML = (state) => {
-    return `<ul>
+    return `
+    <ul>
     ${state
       .map(
-        (document) => `<li data-id=${document.id}>${document.title}
-      ${document.documents.length > 0 ? this.#convertIntoHTML(document.documents) : ""}</li>`
+        (doc) => `<li data-id=${doc.id}>${
+          doc.title
+        } <button class="list__add-button--document">+</button><button class="list__add-button--delete">-</button>
+      ${doc.documents.length > 0 ? this.#convertIntoHTML(doc.documents) : ""}</li>`
       )
       .join(" ")}
     </ul>`;

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -1,0 +1,28 @@
+export default class DocumentList {
+  constructor({ $target, initialState }) {
+    this.state = initialState;
+    this.$target = $target;
+
+    this.render();
+  }
+  setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  render = () => {
+    const stateHTML = this.#convertIntoHTML(this.state);
+    this.$target.innerHTML = stateHTML;
+  };
+
+  #convertIntoHTML = (state) => {
+    return `<ul>
+    ${state
+      .map(
+        (document) => `<li data-id=${document.id}>${document.title}
+      ${document.documents.length > 0 ? this.#convertIntoHTML(document.documents) : ""}</li>`
+      )
+      .join(" ")}
+    </ul>`;
+  };
+}

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -4,18 +4,14 @@ export default class Editor {
   constructor({ $target, initialState, onSetState }) {
     this.$target = $target;
     this.state = initialState;
-
-    this.$title = this.$target.querySelector(".title");
-    this.$content = this.$target.querySelector(".content");
-
+    this.$title = this.$target.querySelector("#title");
+    this.$content = this.$target.querySelector("#content");
     this.$target.append(this.$title, this.$content);
-
     this.$target.addEventListener("input", (e) => {
       const { target } = e;
-      const { name } = target;
-      this.setState({ ...this.state, [name]: target.value });
+      const { id } = target;
+      this.setState({ ...this.state, [id]: target.value });
       onSetState(this.state);
-      target.focus();
     });
 
     this.render();
@@ -34,7 +30,6 @@ export default class Editor {
       console.log(error);
       this.state = { title: "", content: "" };
     }
-
     this.render();
   };
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -7,6 +7,7 @@ export default class Editor {
     this.$title = this.$target.querySelector("#title");
     this.$content = this.$target.querySelector("#content");
     this.$target.append(this.$title, this.$content);
+
     this.$target.addEventListener("input", (e) => {
       const { target } = e;
       const { id } = target;

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,0 +1,39 @@
+//onSetState로 state 변경시 로컬에 바로 저장하고 디바운스로 5초로 api 호출을 하도록한다. 호출이 완료되면 로컬
+export default class Editor {
+  constructor({ $target, initialState = { title: "", content: "" }, onSetState }) {
+    this.$target = $target;
+    this.state = initialState;
+    this.$page = document.createElement("div");
+
+    this.$title = document.createElement("input");
+    this.$title.setAttribute("name", "title");
+    this.$content = document.createElement("textarea");
+    this.$content.setAttribute("name", "content");
+
+    this.$page.append(this.$title, this.$content);
+    // defaultstate가 필요? 테스트 위해 일단 넣자
+    //state = {title, content}
+    this.$page.addEventListener("input", (e) => {
+      const { target } = e;
+      const { name } = target;
+      // input이 들어오면 setstate에서 변경,
+      this.setState({ ...this.state, [name]: target.value });
+      onSetState(this.state);
+      target.focus();
+    });
+
+    this.render();
+  }
+
+  render = () => {
+    this.$title.value = this.state.title;
+    this.$content.value = this.state.content;
+    this.$target.appendChild(this.$page);
+  };
+
+  setState = (nextState) => {
+    this.state = nextState;
+    console.log(this.state);
+    this.render();
+  };
+}

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,22 +1,20 @@
-//onSetState로 state 변경시 로컬에 바로 저장하고 디바운스로 5초로 api 호출을 하도록한다. 호출이 완료되면 로컬
+import { validateEditorState } from "../utils/validation.js";
+
 export default class Editor {
-  constructor({ $target, initialState = { title: "", content: "" }, onSetState }) {
+  constructor({ $target, initialState, onSetState }) {
     this.$target = $target;
     this.state = initialState;
-    this.$page = document.createElement("div");
 
     this.$title = document.createElement("input");
     this.$title.setAttribute("name", "title");
     this.$content = document.createElement("textarea");
     this.$content.setAttribute("name", "content");
 
-    this.$page.append(this.$title, this.$content);
-    // defaultstate가 필요? 테스트 위해 일단 넣자
-    //state = {title, content}
-    this.$page.addEventListener("input", (e) => {
+    this.$target.append(this.$title, this.$content);
+
+    this.$target.addEventListener("input", (e) => {
       const { target } = e;
       const { name } = target;
-      // input이 들어오면 setstate에서 변경,
       this.setState({ ...this.state, [name]: target.value });
       onSetState(this.state);
       target.focus();
@@ -28,12 +26,17 @@ export default class Editor {
   render = () => {
     this.$title.value = this.state.title;
     this.$content.value = this.state.content;
-    this.$target.appendChild(this.$page);
   };
 
   setState = (nextState) => {
-    this.state = nextState;
-    console.log(this.state);
+    try {
+      validateEditorState(nextState);
+      this.state = nextState;
+    } catch (error) {
+      console.log(error);
+      this.state = { title: "", content: "" };
+    }
+
     this.render();
   };
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -5,10 +5,8 @@ export default class Editor {
     this.$target = $target;
     this.state = initialState;
 
-    this.$title = document.createElement("input");
-    this.$title.setAttribute("name", "title");
-    this.$content = document.createElement("textarea");
-    this.$content.setAttribute("name", "content");
+    this.$title = this.$target.querySelector(".title");
+    this.$content = this.$target.querySelector(".content");
 
     this.$target.append(this.$title, this.$content);
 

--- a/src/constant/constant.js
+++ b/src/constant/constant.js
@@ -5,3 +5,5 @@ export const X_USERNAME = "noCheol";
 export const ROUTE_CHANGE_EVENT_NAME = "route-change";
 
 export const ACTIVE = "active";
+
+export const DELAY_TIME = 3000;

--- a/src/constant/constant.js
+++ b/src/constant/constant.js
@@ -1,0 +1,5 @@
+export const API_END_POINT = "https://kdt-frontend.programmers.co.kr/documents";
+
+export const X_USERNAME = "noCheol";
+
+export const ROUTE_CHANGE_EVENT_NAME = "route-change";

--- a/src/constant/constant.js
+++ b/src/constant/constant.js
@@ -3,3 +3,5 @@ export const API_END_POINT = "https://kdt-frontend.programmers.co.kr/documents";
 export const X_USERNAME = "noCheol";
 
 export const ROUTE_CHANGE_EVENT_NAME = "route-change";
+
+export const ACTIVE = "active";

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -2,6 +2,7 @@ body {
   display: flex;
   flex-direction: column;
 }
+
 button {
   background-color: transparent;
   border-radius: 5px;
@@ -9,36 +10,53 @@ button {
   color: lightslategrey;
   cursor: pointer;
 }
+
 button:hover {
   background-color: #dcdcdc;
 }
+
 header {
   margin-bottom: 20px;
   padding-bottom: 10px;
-  border-bottom: 1px solid black;
+  border-bottom: 1px solid lightslategray;
   display: flex;
 }
+
 .header--loading {
   margin: auto 10px;
   opacity: 0;
 }
+
 .header--loading.active {
   opacity: 1;
 }
 
 .App {
   display: flex;
+  width: 80%;
+  margin: auto;
 }
+
 .listPage {
   overflow: auto;
   width: 30%;
   margin: 0;
+  padding: 20px;
+  margin-right: 10px;
+  border-right: 1px solid lightslategray;
 }
-.list {
-  overflow: scroll;
-}
+
 .listPage li {
   cursor: pointer;
+}
+
+.listPage .list__title:hover {
+  background-color: #dcdcdc;
+  border-radius: 5px;
+}
+
+.list {
+  overflow: scroll;
 }
 
 .editorPage {
@@ -52,9 +70,23 @@ header {
   flex-direction: column;
   height: 100%;
 }
+
 .editor.active {
   opacity: 1;
 }
-.content {
+
+.editor #title {
+  outline: none;
+  border: none;
+  border-bottom: 1px solid lightslategray;
+  padding: 5px;
+  margin: 5px;
+  font-size: 24px;
+}
+
+.editor #content {
   height: 100%;
+  font-size: 16px;
+  outline: none;
+  border: none;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,0 +1,60 @@
+body {
+  display: flex;
+  flex-direction: column;
+}
+button {
+  background-color: transparent;
+  border-radius: 5px;
+  border-color: transparent;
+  color: lightslategrey;
+  cursor: pointer;
+}
+button:hover {
+  background-color: #dcdcdc;
+}
+header {
+  margin-bottom: 20px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid black;
+  display: flex;
+}
+.header--loading {
+  margin: auto 10px;
+  opacity: 0;
+}
+.header--loading.active {
+  opacity: 1;
+}
+
+.App {
+  display: flex;
+}
+.listPage {
+  overflow: auto;
+  width: 30%;
+  margin: 0;
+}
+.list {
+  overflow: scroll;
+}
+.listPage li {
+  cursor: pointer;
+}
+
+.editorPage {
+  width: 70%;
+  margin: 0;
+}
+
+.editor {
+  opacity: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.editor.active {
+  opacity: 1;
+}
+.content {
+  height: 100%;
+}

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -1,9 +1,9 @@
 import Editor from "../components/Editor.js";
 import { getDocumentContent, updateDocument } from "../utils/api.js";
-import { getItem, removeItem, setItem } from "../utils/storage.js";
+import { getItem, removeItem, setItem, getKey } from "../utils/storage.js";
 import { debounce } from "../utils/debounce.js";
-import { ACTIVE } from "../constant/constant.js";
-
+import { ACTIVE, DELAY_TIME } from "../constant/constant.js";
+//editorComponent에서 title 변경과 content 변경을 분리하자
 export default class EditorPage {
   constructor({ $target, onEdit }) {
     this.$target = $target;
@@ -13,14 +13,14 @@ export default class EditorPage {
       initialState: { title: "", content: "" },
       onSetState: (editorState) => {
         if (location.pathname === "/") return;
-        const id = location.pathname.split("/")[2];
-        const TEMP_SAVE_KEY = `temp-${id}`;
-        setItem(TEMP_SAVE_KEY, { ...editorState, tempSavedAt: new Date() });
+        const [, , id] = location.pathname.split("/");
+        const tempSaveKey = getKey(id);
+        setItem(tempSaveKey, { ...editorState, tempSavedAt: new Date() });
         debounce(async () => {
           await updateDocument(`/${id}`, editorState);
-          removeItem(TEMP_SAVE_KEY);
+          removeItem(tempSaveKey);
           onEdit();
-        }, 3000);
+        }, DELAY_TIME);
       },
     });
   }
@@ -42,14 +42,14 @@ export default class EditorPage {
       this.hidePage();
       return;
     }
-    const id = pathname.split("/")[2];
+    const [, , id] = pathname.split("/");
     if (id === undefined) {
       this.editorComponent.setState({ title: "", content: "" });
       return;
     }
     const { title, content, updatedAt } = await getDocumentContent(`/${id}`);
-    const TEMP_SAVE_KEY = `temp-${id}`;
-    const tempData = getItem(TEMP_SAVE_KEY, null);
+    const tempSaveKey = getKey(id);
+    const tempData = getItem(tempSaveKey, null);
     if (tempData && tempData.tempSavedAt > updatedAt) {
       if (confirm("임시저장된 데이터가 있습니다. 사용하시겠습니까?")) {
         const { title, content } = tempData;

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -13,10 +13,9 @@ export default class EditorPage {
       initialState: { title: "", content: "" },
       onSetState: (editorState) => {
         if (location.pathname === "/") return;
-        const [_, api, id] = location.pathname.split("/");
+        const id = location.pathname.split("/")[2];
         const TEMP_SAVE_KEY = `temp-${id}`;
         setItem(TEMP_SAVE_KEY, { ...editorState, tempSavedAt: new Date() });
-
         debounce(async () => {
           await updateDocument(`/${id}`, editorState);
           removeItem(TEMP_SAVE_KEY);
@@ -29,6 +28,7 @@ export default class EditorPage {
   showPage = () => {
     const classList = this.$page.classList;
     if (!classList.contains(ACTIVE)) classList.add(ACTIVE);
+    this.$page.querySelector("#content").focus();
   };
 
   hidePage = () => {
@@ -42,8 +42,7 @@ export default class EditorPage {
       this.hidePage();
       return;
     }
-
-    const [_, api, id] = pathname.split("/");
+    const id = pathname.split("/")[2];
     if (id === undefined) {
       this.editorComponent.setState({ title: "", content: "" });
       return;
@@ -59,7 +58,6 @@ export default class EditorPage {
         return;
       }
     }
-
     this.editorComponent.setState({ title, content });
     this.showPage();
   };

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -4,9 +4,6 @@ import { getItem, removeItem, setItem } from "../utils/storage.js";
 import { debounce } from "../utils/debounce.js";
 
 export default class EditorPage {
-  // 여기서 state는 "new" 또는 "id"롤 체크르 하면 될것이다.
-  //editor는 document가 선택되거나 ,add new 가 선택될태 화면이 랜더링 ,여리것 onSetState를 통해 로컬 저장, fetch 처리 등
-  // 그렇다면 여기는 ininitState가 필요없다.state가 필요한가? 필요하면 어떤 형태?
   constructor({ $target, onEdit }) {
     this.$target = $target;
     this.$page = document.createElement("div");
@@ -16,10 +13,10 @@ export default class EditorPage {
       initialState: { title: "", content: "" },
       onSetState: (editorState) => {
         if (location.pathname === "/") return;
-
         const [_, api, id] = location.pathname.split("/");
         const TEMP_SAVE_KEY = `temp-${id}`;
         setItem(TEMP_SAVE_KEY, { ...editorState, tempSavedAt: new Date() });
+
         debounce(async () => {
           await updateDocument(`/${id}`, editorState);
           removeItem(TEMP_SAVE_KEY);
@@ -33,6 +30,7 @@ export default class EditorPage {
     this.$target.appendChild(this.$page);
     this.isRendered = true;
   };
+
   setState = async () => {
     const { pathname } = location;
     if (pathname === "/" && this.isRendered) {
@@ -48,7 +46,6 @@ export default class EditorPage {
     const { title, content, updatedAt } = await getDocumentContent(`/${id}`);
     const TEMP_SAVE_KEY = `temp-${id}`;
     const tempData = getItem(TEMP_SAVE_KEY, null);
-
     if (tempData && tempData.tempSavedAt > updatedAt) {
       if (confirm("임시저장된 데이터가 있습니다. 사용하시겠습니까?")) {
         const { title, content } = tempData;

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -1,0 +1,64 @@
+import Editor from "../components/Editor.js";
+import { getDocumentContent, updateDocument } from "../utils/api.js";
+import { getItem, removeItem, setItem } from "../utils/storage.js";
+import { debounce } from "../utils/debounce.js";
+
+export default class EditorPage {
+  // 여기서 state는 "new" 또는 "id"롤 체크르 하면 될것이다.
+  //editor는 document가 선택되거나 ,add new 가 선택될태 화면이 랜더링 ,여리것 onSetState를 통해 로컬 저장, fetch 처리 등
+  // 그렇다면 여기는 ininitState가 필요없다.state가 필요한가? 필요하면 어떤 형태?
+  constructor({ $target, onEdit }) {
+    this.$target = $target;
+    this.$page = document.createElement("div");
+    this.isRendered = false;
+    this.editorComponent = new Editor({
+      $target: this.$page,
+      initialState: { title: "", content: "" },
+      onSetState: (editorState) => {
+        if (location.pathname === "/") return;
+
+        const [_, api, id] = location.pathname.split("/");
+        const TEMP_SAVE_KEY = `temp-${id}`;
+        setItem(TEMP_SAVE_KEY, { ...editorState, tempSavedAt: new Date() });
+        debounce(async () => {
+          await updateDocument(`/${id}`, editorState);
+          removeItem(TEMP_SAVE_KEY);
+          onEdit();
+        }, 3000);
+      },
+    });
+  }
+
+  render = () => {
+    this.$target.appendChild(this.$page);
+    this.isRendered = true;
+  };
+  setState = async () => {
+    const { pathname } = location;
+    if (pathname === "/" && this.isRendered) {
+      this.$target.removeChild(this.$page);
+      this.isRendered = false;
+      return;
+    }
+    const [_, api, id] = pathname.split("/");
+    if (id === undefined) {
+      this.editorComponent.setState({ title: "", content: "" });
+      return;
+    }
+    const { title, content, updatedAt } = await getDocumentContent(`/${id}`);
+    const TEMP_SAVE_KEY = `temp-${id}`;
+    const tempData = getItem(TEMP_SAVE_KEY, null);
+
+    if (tempData && tempData.tempSavedAt > updatedAt) {
+      if (confirm("임시저장된 데이터가 있습니다. 사용하시겠습니까?")) {
+        const { title, content } = tempData;
+        this.editorComponent.setState({ title, content });
+        this.render();
+        return;
+      }
+    }
+
+    this.editorComponent.setState({ title, content });
+    this.render();
+  };
+}

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -2,12 +2,12 @@ import Editor from "../components/Editor.js";
 import { getDocumentContent, updateDocument } from "../utils/api.js";
 import { getItem, removeItem, setItem } from "../utils/storage.js";
 import { debounce } from "../utils/debounce.js";
+import { ACTIVE } from "../constant/constant.js";
 
 export default class EditorPage {
   constructor({ $target, onEdit }) {
     this.$target = $target;
-    this.$page = document.createElement("div");
-    this.isRendered = false;
+    this.$page = this.$target.querySelector(".editor");
     this.editorComponent = new Editor({
       $target: this.$page,
       initialState: { title: "", content: "" },
@@ -26,18 +26,23 @@ export default class EditorPage {
     });
   }
 
-  render = () => {
-    this.$target.appendChild(this.$page);
-    this.isRendered = true;
+  showPage = () => {
+    const classList = this.$page.classList;
+    if (!classList.contains(ACTIVE)) classList.add(ACTIVE);
+  };
+
+  hidePage = () => {
+    const classList = this.$page.classList;
+    if (classList.contains(ACTIVE)) classList.remove(ACTIVE);
   };
 
   setState = async () => {
     const { pathname } = location;
-    if (pathname === "/" && this.isRendered) {
-      this.$target.removeChild(this.$page);
-      this.isRendered = false;
+    if (pathname === "/") {
+      this.hidePage();
       return;
     }
+
     const [_, api, id] = pathname.split("/");
     if (id === undefined) {
       this.editorComponent.setState({ title: "", content: "" });
@@ -50,12 +55,12 @@ export default class EditorPage {
       if (confirm("임시저장된 데이터가 있습니다. 사용하시겠습니까?")) {
         const { title, content } = tempData;
         this.editorComponent.setState({ title, content });
-        this.render();
+        this.showPage();
         return;
       }
     }
 
     this.editorComponent.setState({ title, content });
-    this.render();
+    this.showPage();
   };
 }

--- a/src/pages/ListPage.js
+++ b/src/pages/ListPage.js
@@ -2,6 +2,7 @@ import DocumentList from "../components/DocumentList.js";
 import { getDocumentsTree, createDocument, deleteDocument } from "../utils/api.js";
 import { push } from "../utils/router.js";
 import { ACTIVE } from "../constant/constant.js";
+import { validateTitle } from "../utils/validation.js";
 
 export default class ListPage {
   constructor({ $target }) {
@@ -45,7 +46,7 @@ const createDocumentByButton = (button, onSubmit) => {
     $form.addEventListener("submit", async (e) => {
       e.preventDefault();
       const title = $input.value.trim();
-      if (title === "") {
+      if (!validateTitle(title)) {
         alert("title을 입력해주요");
         return;
       }

--- a/src/pages/ListPage.js
+++ b/src/pages/ListPage.js
@@ -1,21 +1,23 @@
 import DocumentList from "../components/DocumentList.js";
 import { getDocumentsTree, createDocument, deleteDocument } from "../utils/api.js";
 import { push } from "../utils/router.js";
-// 컴포넌트는 화면 출력에 , page에서 복잡한 로직들 처리
-// 출력을 어떻게 해주어야 되나? initialState를 어떻게 처리
-// trim 공백 처리
+import { ACTIVE } from "../constant/constant.js";
+
 export default class ListPage {
   constructor({ $target }) {
     this.documentList = new DocumentList({
       $target,
       initialState: [],
       onClickButton: (target) => {
-        if (target.tagName === "LI") push(target.dataset.id);
-        createDocumentByButton(target, () => this.render());
-        deleteDocumentByButton(target, () => this.render());
+        if (target.tagName === "SPAN") {
+          const { id } = target.closest("li").dataset;
+          push(id);
+        } else if (target.tagName === "BUTTON") {
+          createDocumentByButton(target, async () => await this.render());
+          deleteDocumentByButton(target, async () => await this.render());
+        }
       },
     });
-
     this.render();
   }
 
@@ -27,18 +29,17 @@ export default class ListPage {
 
 const createDocumentByButton = (button, onSubmit) => {
   const { classList } = button;
-  if ((classList.contains("list__add-button--root") || classList.contains("list__add-button--document")) && !classList.contains("active")) {
+  if ((classList.contains("list__add-button--root") || classList.contains("list__add-button--document")) && !classList.contains(ACTIVE)) {
     const $li = button.closest("li");
     const $form = document.createElement("form");
     const $input = document.createElement("input");
     $form.appendChild($input);
     button.before($form);
-    classList.add("active");
+    classList.add(ACTIVE);
     $input.focus();
-
     $input.addEventListener("blur", () => {
       $form.remove();
-      classList.remove("active");
+      classList.remove(ACTIVE);
     });
 
     $form.addEventListener("submit", async (e) => {

--- a/src/pages/ListPage.js
+++ b/src/pages/ListPage.js
@@ -1,0 +1,87 @@
+import DocumentList from "../components/DocumentList.js";
+import { getDocumentsTree, createDocument, deleteDocument } from "../utils/api.js";
+import { push } from "../utils/router.js";
+// 컴포넌트는 화면 출력에 , page에서 복잡한 로직들 처리
+// 출력을 어떻게 해주어야 되나? initialState를 어떻게 처리
+// trim 공백 처리
+export default class ListPage {
+  constructor({ $target }) {
+    this.documentList = new DocumentList({
+      $target,
+      initialState: [],
+      onClickButton: (target) => {
+        if (target.tagName === "LI") push(target.dataset.id);
+        // 생성 라우트 처리
+        createDocumentByTarget({
+          target,
+          onSubmit: () => this.render(),
+        });
+
+        deleteDocumentByTarget({
+          target,
+          onClick: () => {
+            this.render();
+          },
+        });
+      },
+    });
+    // page에서의 render와  setState에 대해 생각해보자, page는 component와 같이 구성해야되는가?
+    this.render();
+  }
+
+  render = async () => {
+    const documents = await getDocumentsTree();
+    this.documentList.setState(documents);
+  };
+}
+
+//class 수정
+const createDocumentByTarget = ({ target, onSubmit }) => {
+  const { classList } = target;
+  if ((classList.contains("button__add-root") || classList.contains("button__add-document")) && !classList.contains("active")) {
+    const $li = target.closest("li");
+    const $form = document.createElement("form");
+    const $input = document.createElement("input");
+
+    $form.appendChild($input);
+    target.before($form);
+    classList.add("active");
+    $input.focus();
+
+    $input.addEventListener("blur", () => {
+      $form.remove();
+      classList.remove("active");
+    });
+    // 반복과정 처리
+    $form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const title = $input.value;
+
+      if ($li) {
+        const { id } = $li.dataset;
+        const { id: newId } = await createDocument(title, id);
+        push(newId);
+      } else {
+        const { id: newId } = await createDocument(title);
+        push(newId);
+      }
+
+      onSubmit();
+      $input.blur();
+    });
+  }
+};
+
+const deleteDocumentByTarget = async ({ target, onClick }) => {
+  if (target.classList.contains("button__delete")) {
+    const { pathname } = location;
+    const [_, api, nowId] = pathname.split("/");
+    const $li = target.closest("li");
+    const { id } = $li.dataset;
+    if (id) {
+      await deleteDocument(`/${id}`);
+      push();
+      onClick();
+    }
+  }
+};

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,31 +1,33 @@
-const API_END_POINT = "https://kdt-frontend.programmers.co.kr/documents";
-const X_USERNAME = "noCheol";
-const DEFAULT_HEADERS = { "x-username": X_USERNAME };
+import { API_END_POINT, X_USERNAME } from "../constant/constant.js";
+import { hideLoading, showLoading } from "./loadingHandler.js";
 
 const request = async (url, opitons = {}) => {
+  showLoading();
   try {
-    const res = await fetch(`${API_END_POINT}${url}`, { ...opitons, headers: { ...DEFAULT_HEADERS, "Content-Type": "application/json" } });
+    const res = await fetch(`${API_END_POINT}${url}`, { ...opitons, headers: { "x-username": X_USERNAME, "Content-Type": "application/json" } });
     if (res.ok) return await res.json();
     throw new Error("api 통신 중 이상");
   } catch (error) {
     console.log(error.message);
+  } finally {
+    hideLoading();
   }
 };
 
 export const getDocumentsTree = async () => {
-  return await request();
+  return await request("");
 };
 
 export const getDocumentContent = async (url) => {
   return await request(url);
 };
-// 생성시 id 받아서 parent에 넣어준다.그리고 return으로 {id, title, createdAt, updataedAt}을 받는다.
+
 export const createDocument = async (title, parentId = null) => {
   const bodyValue = JSON.stringify({ title, parent: parentId });
   const response = await request("", { method: "POST", body: bodyValue });
   return response;
 };
-// url에는 `/${id}` 같은 형식으로 들어올것이다.
+
 export const updateDocument = async (url, value) => {
   const bodyValue = JSON.stringify(value);
   await request(url, { method: "PUT", body: bodyValue });

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,28 @@
+const API_END_POINT = "https://kdt-frontend.programmers.co.kr";
+const X_USERNAME = "noCheol";
+const DEFAULT_HEADERS = { "x-username": X_USERNAME };
+
+const request = async (url, opitons = {}) => {
+  try {
+    const res = await fetch(`${API_END_POINT}${url}`, { ...opitons, headers: { ...DEFAULT_HEADERS, "Content-Type": "application/json" } });
+    if (res.ok) return await res.json();
+    throw new Error("api 통신 중 이상");
+  } catch (error) {
+    console.log(error.message);
+    return [];
+  }
+};
+
+export const getDocumentsTree = async () => {
+  return await request("/documents");
+};
+
+export const getDocumentContent = async (url) => {
+  return await request(url);
+};
+
+export const createDocument = async () => {};
+
+export const updateDocument = async () => {};
+
+export const deleteDocument = async () => {};

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,4 @@
-const API_END_POINT = "https://kdt-frontend.programmers.co.kr";
+const API_END_POINT = "https://kdt-frontend.programmers.co.kr/documents";
 const X_USERNAME = "noCheol";
 const DEFAULT_HEADERS = { "x-username": X_USERNAME };
 
@@ -9,20 +9,28 @@ const request = async (url, opitons = {}) => {
     throw new Error("api 통신 중 이상");
   } catch (error) {
     console.log(error.message);
-    return [];
   }
 };
 
 export const getDocumentsTree = async () => {
-  return await request("/documents");
+  return await request();
 };
 
 export const getDocumentContent = async (url) => {
   return await request(url);
 };
+// 생성시 id 받아서 parent에 넣어준다.그리고 return으로 {id, title, createdAt, updataedAt}을 받는다.
+export const createDocument = async (title, parentId = null) => {
+  const bodyValue = JSON.stringify({ title, parent: parentId });
+  const response = await request("", { method: "POST", body: bodyValue });
+  return response;
+};
+// url에는 `/${id}` 같은 형식으로 들어올것이다.
+export const updateDocument = async (url, value) => {
+  const bodyValue = JSON.stringify(value);
+  await request(url, { method: "PUT", body: bodyValue });
+};
 
-export const createDocument = async () => {};
-
-export const updateDocument = async () => {};
-
-export const deleteDocument = async () => {};
+export const deleteDocument = async (url) => {
+  await request(url, { method: "DELETE" });
+};

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,10 @@
+const setDebounce = () => {
+  let timer = null;
+  return (callback, delayTime) => {
+    if (timer) clearTimeout(timer);
+
+    timer = setTimeout(callback, delayTime);
+  };
+};
+
+export const debounce = setDebounce();

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -2,7 +2,6 @@ const setDebounce = () => {
   let timer = null;
   return (callback, delayTime) => {
     if (timer) clearTimeout(timer);
-
     timer = setTimeout(callback, delayTime);
   };
 };

--- a/src/utils/loadingHandler.js
+++ b/src/utils/loadingHandler.js
@@ -1,0 +1,12 @@
+import { ACTIVE } from "../constant/constant.js";
+
+const $loadingBox = document.querySelector(".header--loading");
+const classList = $loadingBox.classList;
+
+export const showLoading = () => {
+  if (!classList.contains(ACTIVE)) classList.add(ACTIVE);
+};
+
+export const hideLoading = () => {
+  if (classList.contains(ACTIVE)) classList.remove(ACTIVE);
+};

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,12 +1,15 @@
 import { ROUTE_CHANGE_EVENT_NAME } from "../constant/constant.js";
 
 export const initRouter = (onRoute) => {
-  history.replaceState(null, null, "/");
   window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
     const url = e.detail;
     history.pushState(null, null, `${url}`);
     onRoute();
   });
+
+  const { pathname } = location;
+  const [, , id] = pathname.split("/");
+  push(id);
 };
 
 export const push = (id = null) => {

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,0 +1,13 @@
+export const ROUTE_CHANGE_EVENT_NAME = "route-change";
+// 상수화 필요
+export const initRouter = (onRoute) => {
+  window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
+    const id = e.detail;
+    history.pushState(null, null, `/documents/${id}`);
+    onRoute();
+  });
+};
+
+export const push = (id) => {
+  window.dispatchEvent(new CustomEvent(ROUTE_CHANGE_EVENT_NAME, { detail: id }));
+};

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,13 +1,18 @@
-export const ROUTE_CHANGE_EVENT_NAME = "route-change";
-// 상수화 필요
+import { ROUTE_CHANGE_EVENT_NAME } from "../constant/constant.js";
+
 export const initRouter = (onRoute) => {
+  history.replaceState(null, null, "/");
   window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
-    const id = e.detail;
-    history.pushState(null, null, `/documents/${id}`);
+    const url = e.detail;
+    history.pushState(null, null, `${url}`);
     onRoute();
   });
 };
 
-export const push = (id) => {
-  window.dispatchEvent(new CustomEvent(ROUTE_CHANGE_EVENT_NAME, { detail: id }));
+export const push = (id = null) => {
+  if (id !== null) {
+    window.dispatchEvent(new CustomEvent(ROUTE_CHANGE_EVENT_NAME, { detail: `/documents/${id}` }));
+  } else {
+    window.dispatchEvent(new CustomEvent(ROUTE_CHANGE_EVENT_NAME, { detail: `/` }));
+  }
 };

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -19,3 +19,7 @@ export const getItem = (key, defualtValue) => {
 export const removeItem = (key) => {
   storage.removeItem(key);
 };
+
+export const getKey = (id) => {
+  return `TEMP-${id}`;
+};

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,17 @@
+const storage = window.localStorage;
+
+export const setItem = (key, value) => {
+  const stringifiedValue = JSON.stringify(value);
+  storage.setItem(key, stringifiedValue);
+};
+export const getItem = (key, defualtValue) => {
+  try {
+    const storedValue = storage.getItem(key);
+    if (storedValue) return JSON.parse(storedValue);
+    return defualtValue;
+  } catch (error) {
+    console.log(error.message);
+    return defualtValue;
+  }
+};
+export const removeItem = (key) => {};

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -4,6 +4,7 @@ export const setItem = (key, value) => {
   const stringifiedValue = JSON.stringify(value);
   storage.setItem(key, stringifiedValue);
 };
+
 export const getItem = (key, defualtValue) => {
   try {
     const storedValue = storage.getItem(key);
@@ -14,4 +15,7 @@ export const getItem = (key, defualtValue) => {
     return defualtValue;
   }
 };
-export const removeItem = (key) => {};
+
+export const removeItem = (key) => {
+  storage.removeItem(key);
+};

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,15 +1,27 @@
 export const validateListState = (nextState) => {
   if (!Array.isArray(nextState)) throw new Error("listState가 배열이 아닙니다.");
   if (nextState.length > 0) {
-    if (!nextState.every((doc) => doc.hasOwnProperty("id") && doc.hasOwnProperty("title") && doc.hasOwnProperty("documents")))
-      throw new Error("listState가 적절한 형태가 아닙니다. ");
     for (const doc of nextState) {
-      validateListState(doc.documents);
+      checkObject(doc, ["id", "title", "documents"]);
     }
   }
 };
 
 export const validateEditorState = (nextState) => {
   if (!typeof nextState === "object") throw new Error("editorState가 object가 아닙니다. ");
-  if (!(nextState.hasOwnProperty("title") && nextState.hasOwnProperty("content"))) throw new Error("editorState가 적절한 형태가 아닙니다.");
+  checkObject(nextState, ["title", "content"]);
+};
+
+const checkObject = (obj, checkKeys) => {
+  for (const key of checkKeys) {
+    if (!obj.hasOwnProperty(key)) throw new Error(`${key}가 없습니다.`);
+  }
+};
+
+export const validateTitle = (titleValue) => {
+  const title = titleValue.tirm();
+  if (title === "") {
+    return false;
+  }
+  return true;
 };

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,21 @@
+//validation 은 submit전, change 전
+// list, editor 의 state
+//
+export const validateListState = (nextState) => {
+  if (!Array.isArray(nextState)) throw new Error("listState가 배열이 아닙니다.");
+
+  if (nextState.length > 0) {
+    if (!nextState.every((doc) => doc.hasOwnProperty("id") && doc.hasOwnProperty("title") && doc.hasOwnProperty("documents")))
+      throw new Error("listState가 적절한 형태가 아닙니다. ");
+    for (const doc of nextState) {
+      validateListState(doc.documents);
+    }
+  }
+};
+//list 에서 필수는 array인지, 안에 요소가 id, title 이 있는지 ,documnets에서 대해서 반복
+
+//editor는 title, content
+export const validateEditorState = (nextState) => {
+  if (!typeof nextState === "object") throw new Error("editorState가 object가 아닙니다. ");
+  if (!(nextState.hasOwnProperty("title") && nextState.hasOwnProperty("content"))) throw new Error("editorState가 적절한 형태가 아닙니다.");
+};

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,9 +1,5 @@
-//validation 은 submit전, change 전
-// list, editor 의 state
-//
 export const validateListState = (nextState) => {
   if (!Array.isArray(nextState)) throw new Error("listState가 배열이 아닙니다.");
-
   if (nextState.length > 0) {
     if (!nextState.every((doc) => doc.hasOwnProperty("id") && doc.hasOwnProperty("title") && doc.hasOwnProperty("documents")))
       throw new Error("listState가 적절한 형태가 아닙니다. ");
@@ -12,9 +8,7 @@ export const validateListState = (nextState) => {
     }
   }
 };
-//list 에서 필수는 array인지, 안에 요소가 id, title 이 있는지 ,documnets에서 대해서 반복
 
-//editor는 title, content
 export const validateEditorState = (nextState) => {
   if (!typeof nextState === "object") throw new Error("editorState가 object가 아닙니다. ");
   if (!(nextState.hasOwnProperty("title") && nextState.hasOwnProperty("content"))) throw new Error("editorState가 적절한 형태가 아닙니다.");


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[배포링크](https://fedc-4-5-project-notion-vanilla-js-psi.vercel.app/)
- 바닐라 js만 이용해 노션 클로닝
- App컴포넌트 안에서 listPage, editorPage를 넣어서 구현을 했고 , 각 page는 이벤트를 실행하고, 페치 작업등을 이곳에서 해서 state를 받아서  component에 넘겨줍니다. 그리고 각 컴포넌트는 state로 화면을 렌더합니다. 

<img src="https://github.com/prgrms-fe-devcourse/FEDC4-5_Project_Notion_VanillaJS/assets/61609327/dc3493a3-f3aa-41e6-a545-ceafbeadce0e" height="300px" width="300px">


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- [x] 화면 좌측에 Root documents를 불러와서 렌더링
	- [x] 해당 document를 우측 편집에 title과 content 렌더
	- [x] 해당 document 하위 document들을 트리형태로 렌더
	- [x] 각 document에 +버튼을 만들고 해당 버튼을 통해 하위 document 생성, 생성시 우측에 editor 렌더
- [x] 저장 버튼 없이 자동 저장
- [x] history API로 SPA형태 
	- [x] 루트 접속시 편집기 선택x
	- [x] /documents/{documentId}로 접속시 해당 편집기로 이동 
- 보너스 요구사항
	- [ ] div 와 contentEditable을 이용해서 기능 추가
	- [ ] 편집기 최하단에 하위 document링크 렌더 
	- [ ] 편집기 내에 다른 document name을 적을 경우, 링크거는 기능 추가
	 
## ✅ 피드백 반영사항
validateTitle구현
getKey 구현
validate 반복되는 부분 함수로 변경
오타수정



## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
-  component는 state만 받아 보여 주는 기능만 하고, page에서 대부분 로직이 실행되도록 했는데, page 부분이 너무 복잡해진 것 같습니다. 
-  element의 class는 js에서 element 구분을 위해서 사용하는것도 괜찮은 사용방법인가요?
	- js에서 target을 구분할때 classList.contains()를 사용해서 구분하는 경우
- list를 fetch를 통해 불러 왔을때 깊이가 정해져 있지 않아서 관련 함수들은 재귀를 통해 작동하도록 만들었습니다.  재귀 방법을 사용해도 괜찮을까요? 만약 재귀를 피해야된다면 이런 경우는 어떤 방식이 좋을까요?
- 완성 못한 요구사항에 대해서 천천히 완성해 보겠습니다. 


